### PR TITLE
Convert info.json from utf-8-sig to utf-8

### DIFF
--- a/customwelcomes/info.json
+++ b/customwelcomes/info.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "name": "customwelcomes",
   "author": ["くずま#0420"],
   "short": "Custom welcome messages and procedurally generated images",


### PR DESCRIPTION
After fixing issues for the bot, I noticed an encoding issue with customwelcome's `info.json` when RepoManager was trying to read it:
```
Apr  9 18:27:06 ubuntu-x-xxxxx-xxx-xxxx-xx python[571]: [2023-04-09 18:27:06] [ERROR] red.downloader: Invalid JSON information file at path: /root/RedBot/data/kyaa/cogs/RepoManager/repos/UBCAni-Cogs/customwelcomes/info.json
Apr  9 18:27:06 ubuntu-x-xxxxx-xxx-xxxx-xx python[571]: Error: Unexpected UTF-8 BOM (decode using utf-8-sig): line 1 column 1 (char 0)
```

This PR fixes it by converting the info.json from `utf-8-sig` to `utf-8` with the following python snippet:
```python
theFile = "info.json"
s = open(theFile, mode='r', encoding='utf-8-sig').read()
open(theFile, mode='w', encoding='utf-8').write(s)
